### PR TITLE
feat: hash seed to allow high integer values

### DIFF
--- a/noise.go
+++ b/noise.go
@@ -58,9 +58,10 @@ func grad(hash int, x, y, z float64) float64 {
 }
 
 func getNoise(seed int, x, y, z float64) float64 {
-	x += float64(seed)
-	y += float64(seed)
-	z += float64(seed)
+	hashValue := uint32(seed)*1664525 + 640406589
+	x += float64(hashValue & 0xFF)
+	y += float64(hashValue >> 8 & 0xFF)
+	z += float64(hashValue >> 16 & 0xFF)
 
 	X := int(math.Floor(x)) & 255
 	Y := int(math.Floor(y)) & 255


### PR DESCRIPTION
Hashing the seed and using 8 bits to add to x,y,z limits the possibilities. But it avoids overflowing on the permutation array and having X = 0 when we have high value seeds.