### PR TITLE
chore: clean API to use Sources only in Operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,22 +96,19 @@ The Divide operator divides the value from a Source A by the value from a Source
 The Invert operator inverts the value. i.e. 1 => -1 and -1 => 1.
 
 #### Max
-The Max operator returns the highest value between a Source and the its parameter Max.
+The Max operator returns the highest value between two Sources.
 
 #### Min
-The Min operator returns the lowest value between a Source and the its parameter Min.
+The Min operator returns the lowest value between two Sources.
 
 #### Clamp
-The Clamp operator returns the value from a Source, clamped between [Min;Max].
+The Clamp operator returns the value from a Source, clamped between the Sources [Min;Max].
 
 #### Abs
 The Abs operator returns the absolute value from a Source, limiting it to [0;1].
 
 #### Power
 The Power operator returns the value from a Source A, powered by the value from a Source B.
-
-#### Exponent
-The Exponent operator returns the value from a Source, powered by Exponent.
 
 ### Result
 Once your generator is built, you can either fetch the value for one position:
@@ -162,8 +159,8 @@ generator := Multiply{
                 Seed:        seed,
             },
         },
-        Min: 0.0,
-        Max: 1.0,
+        Min: Constant{0.0},
+        Max: Constant{1.0},
     },
 }
 ```

--- a/operator.go
+++ b/operator.go
@@ -53,49 +53,47 @@ func (invert Invert) GetValue(x, y, z float64) float64 {
 
 // Max takes 1 source and a maximum value.
 type Max struct {
-	Source SourceInterface
-	Max    float64
+	SourceA SourceInterface
+	SourceB SourceInterface
 }
 
-// GetValue returns the value from Source, or the Max value if it is higher.
+// GetValue returns the value from SourceA, or the Max value if it is higher.
 func (max Max) GetValue(x, y, z float64) float64 {
-	value := max.Source.GetValue(x, y, z)
-
-	value = math.Max(value, max.Max)
+	value := math.Max(max.SourceA.GetValue(x, y, z), max.SourceB.GetValue(x, y, z))
 
 	return value
 }
 
 // Min takes 1 source and a minimum value.
 type Min struct {
-	Source SourceInterface
-	Min    float64
+	SourceA SourceInterface
+	SourceB SourceInterface
 }
 
-// GetValue returns the value from Source, or the Min value if it is lower.
+// GetValue returns the value from SourceA, or the Min value if it is lower.
 func (min Min) GetValue(x, y, z float64) float64 {
-	value := min.Source.GetValue(x, y, z)
-
-	value = math.Min(value, min.Min)
+	value := math.Min(min.SourceA.GetValue(x, y, z), min.SourceB.GetValue(x, y, z))
 
 	return value
 }
 
 // Clamp takes 1 source and min/max values.
 type Clamp struct {
-	Source   SourceInterface
-	Min, Max float64
+	Source               SourceInterface
+	SourceMin, SourceMax SourceInterface
 }
 
-// GetValue returns the value from Source, clamped between Min/Max.
+// GetValue returns the value from Source, clamped between Min/SourceB.
 func (clamp Clamp) GetValue(x, y, z float64) float64 {
 	value := clamp.Source.GetValue(x, y, z)
+	minValue := clamp.SourceMin.GetValue(x, y, z)
+	maxValue := clamp.SourceMax.GetValue(x, y, z)
 
-	if clamp.Min > clamp.Max {
+	if minValue > maxValue {
 		return math.NaN()
 	}
-	value = math.Min(value, clamp.Max)
-	value = math.Max(value, clamp.Min)
+	value = math.Min(value, maxValue)
+	value = math.Max(value, minValue)
 
 	return value
 }
@@ -119,17 +117,4 @@ type Power struct {
 // GetValue returns the value from SourceA, powered by the value from SourceB.
 func (power Power) GetValue(x, y, z float64) float64 {
 	return math.Pow(power.SourceA.GetValue(x, y, z), power.SourceB.GetValue(x, y, z))
-}
-
-// Exponent takes 1 source, and an exponent.
-type Exponent struct {
-	Source   SourceInterface
-	Exponent float64
-}
-
-// GetValue returns the value from Source, powered by Exponent.
-func (exponent Exponent) GetValue(x, y, z float64) float64 {
-	value := exponent.Source.GetValue(z, y, z)
-
-	return math.Pow(math.Abs((value+1.0)/2.0), exponent.Exponent)*2.0 - 1.0
 }

--- a/operator.go
+++ b/operator.go
@@ -57,7 +57,7 @@ type Max struct {
 	SourceB SourceInterface
 }
 
-// GetValue returns the value from SourceA, or the Max value if it is higher.
+// GetValue returns the value from SourceA, or the SourceB value if it is higher.
 func (max Max) GetValue(x, y, z float64) float64 {
 	value := math.Max(max.SourceA.GetValue(x, y, z), max.SourceB.GetValue(x, y, z))
 
@@ -70,7 +70,7 @@ type Min struct {
 	SourceB SourceInterface
 }
 
-// GetValue returns the value from SourceA, or the Min value if it is lower.
+// GetValue returns the value from SourceA, or the SourceB value if it is lower.
 func (min Min) GetValue(x, y, z float64) float64 {
 	value := math.Min(min.SourceA.GetValue(x, y, z), min.SourceB.GetValue(x, y, z))
 
@@ -83,7 +83,7 @@ type Clamp struct {
 	SourceMin, SourceMax SourceInterface
 }
 
-// GetValue returns the value from Source, clamped between Min/SourceB.
+// GetValue returns the value from Source, clamped between the values of SourceMin/SourceMax.
 func (clamp Clamp) GetValue(x, y, z float64) float64 {
 	value := clamp.Source.GetValue(x, y, z)
 	minValue := clamp.SourceMin.GetValue(x, y, z)

--- a/operator_test.go
+++ b/operator_test.go
@@ -134,12 +134,12 @@ func TestMax_GetValue(t *testing.T) {
 		want      float64
 	}{
 		{"max1", Max{
-			Source: Constant{0.2},
-			Max:    0.3,
+			SourceA: Constant{0.2},
+			SourceB: Constant{0.3},
 		}, 0.3},
 		{"max2", Max{
-			Source: Constant{0.3},
-			Max:    0.2,
+			SourceA: Constant{0.3},
+			SourceB: Constant{0.2},
 		}, 0.3},
 	}
 
@@ -160,12 +160,12 @@ func TestMin_GetValue(t *testing.T) {
 		want      float64
 	}{
 		{"min1", Min{
-			Source: Constant{0.2},
-			Min:    0.1,
+			SourceA: Constant{0.2},
+			SourceB: Constant{0.1},
 		}, 0.1},
 		{"min2", Min{
-			Source: Constant{0.1},
-			Min:    0.2,
+			SourceA: Constant{0.1},
+			SourceB: Constant{0.2},
 		}, 0.1},
 	}
 
@@ -186,19 +186,19 @@ func TestClamp_GetValue(t *testing.T) {
 		want      float64
 	}{
 		{"clamp1", Clamp{
-			Source: Constant{0.2},
-			Min:    0.1,
-			Max:    0.3,
+			Source:    Constant{0.2},
+			SourceMin: Constant{0.1},
+			SourceMax: Constant{0.3},
 		}, 0.2},
 		{"clamp2", Clamp{
-			Source: Constant{-0.1},
-			Min:    0.1,
-			Max:    0.3,
+			Source:    Constant{-0.1},
+			SourceMin: Constant{0.1},
+			SourceMax: Constant{0.3},
 		}, 0.1},
 		{"clamp3", Clamp{
-			Source: Constant{0.4},
-			Min:    0.1,
-			Max:    0.3,
+			Source:    Constant{0.4},
+			SourceMin: Constant{0.1},
+			SourceMax: Constant{0.3},
 		}, 0.3},
 	}
 

--- a/source.go
+++ b/source.go
@@ -1,6 +1,6 @@
 package noisy
 
-// SourceInterface defines a Source/Operator.
+// SourceInterface defines a SourceA/Operator.
 //
 // Its method GetValue returns a value between [-1;1], for a given 3 dimension position.
 type SourceInterface interface {

--- a/source.go
+++ b/source.go
@@ -1,6 +1,6 @@
 package noisy
 
-// SourceInterface defines a SourceA/Operator.
+// SourceInterface defines a Source/Operator.
 //
 // Its method GetValue returns a value between [-1;1], for a given 3 dimension position.
 type SourceInterface interface {


### PR DESCRIPTION
Operators should only receive Sources. Whenever we want to receive a float64 as input, we can use the Constant source